### PR TITLE
Refactor scanner to log malware detections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Malware Scanner Service
 
 This repository contains the code to build a pipeline that scans objects
-uploaded to GCS for malware, moving the documents to a clean or quarantined
-bucket depending on the malware scan status.
+uploaded to GCS for malware and logs any detections. Files remain in place
+and can be acted upon separately.
 
 It illustrates how to use Cloud Run and Eventarc to build such a pipeline.
 
@@ -18,8 +18,8 @@ Run and Eventarc.
 ## Using Environment variables in the configuration
 
 The tutorial above uses a configuration file `config.json` built into the Docker
-container for the configuration of the unscanned, clean, quarantined and CVD
-updater cloud storage buckets.
+container for the configuration of the buckets to scan and the CVD
+updater cloud storage bucket.
 
 Environment variables can be used to vary the deployment in 2 ways:
 
@@ -56,13 +56,7 @@ For example, the `CONFIG_JSON` environment variable could be defined in a file
 ```yaml
 CONFIG_JSON: |
   {
-    "buckets": [
-      {
-        "unscanned": "unscanned-bucket-name",
-        "clean": "clean-bucket-name",
-        "quarantined": "quarantined-bucket-name"
-      }
-    ],
+    "buckets": ["bucket-name"],
     "ClamCvdMirrorBucket": "cvd-mirror-bucket-name",
     "fileExclusionPatterns": [],
     ignoreZeroLengthFiles: false
@@ -106,13 +100,7 @@ resource "google_cloud_run_v2_service" "malware-scanner" {
       env {
         name = "CONFIG_JSON"
         value = jsonencode({
-          buckets = [
-            {
-              unscanned   = "unscanned-bucket-name",
-              clean       = "clean-bucket-name",
-              quarantined = "quarantined-bucket-name"
-            }
-          ]
+          buckets = ["bucket-name"]
           ClamCvdMirrorBucket = "cvd-mirror-bucket-name",
           fileExclusionPatterns = [],
           ignoreZeroLengthFiles = false
@@ -152,8 +140,8 @@ be specified, for example `"i"` for case-insensitive matches:
 ]
 ```
 
-Files matching these patterns will be ignored by the scanner, and left in the
-`unscanned` bucket, and an `ignored-files` counter incremented.
+Files matching these patterns will be ignored by the scanner, remain in the
+original bucket, and an `ignored-files` counter incremented.
 
 Helpful tools for regular expressions include the
 [Regular Expression Cheatsheet](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Cheatsheet),

--- a/cloudrun-malware-scanner/config.json.tmpl
+++ b/cloudrun-malware-scanner/config.json.tmpl
@@ -3,8 +3,7 @@
     "# Configuration file for malware-scanner service.",
     "# ----",
     "#",
-    "# 'buckets' is a list of objects specifying source/destination buckets for scanning, allowing the service to handle multiple buckets",
-    "# Each object must have the 3 properties 'unscanned', 'clean' and 'quarantined', specifying the bucket names to use.",
+    "# 'buckets' is a list of bucket names that will be scanned for malware.",
     "#",
     "# 'ClamCvdMirrorBucket' is a GCS bucket used to mirror the clamav database definition files to prevent overloading the Clam servers",
     "# and being rate limited/blacklisted. Its contents are maintained by the updateCvdMirror.sh script",
@@ -50,13 +49,7 @@
     "#",
     "# Note: This comments property is optional and can be removed."
   ],
-  "buckets": [
-    {
-      "unscanned": "unscanned-bucket-name",
-      "clean": "clean-bucket-name",
-      "quarantined": "quarantined-bucket-name"
-    }
-  ],
+  "buckets": ["bucket-name"],
   "ClamCvdMirrorBucket": "cvd-mirror-bucket-name",
   "fileExclusionPatterns": [],
   "ignoreZeroLengthFiles": false,

--- a/cloudrun-malware-scanner/config.ts
+++ b/cloudrun-malware-scanner/config.ts
@@ -23,14 +23,8 @@ import {Storage} from '@google-cloud/storage';
  * Values are read from the JSON configuration file.
  * See {@link readAndVerifyConfig}.
  */
-export type BucketDefs = {
-  unscanned: string;
-  clean: string;
-  quarantined: string;
-};
-
 export type Config = {
-  buckets: Array<BucketDefs>;
+  buckets: string[];
   ClamCvdMirrorBucket: string;
   fileExclusionPatterns?: Array<string | Array<string>>;
   fileExclusionRegexps: Array<RegExp>;
@@ -42,10 +36,6 @@ export type Config = {
     fileExtensionDenyList: string[];
   };
 };
-
-const BUCKET_TYPES = ['unscanned', 'clean', 'quarantined'] as Array<
-  keyof BucketDefs
->;
 
 /**
  * Read configuration from JSON configuration file, parse, verify
@@ -99,26 +89,14 @@ async function validateConfig(config: any, storage: Storage): Promise<Config> {
   // Check buckets are specified and exist.
   let success = true;
   for (let x = 0; x < config.buckets.length; x++) {
-    const bucketDefs = config.buckets[x] as BucketDefs;
-    for (const bucketType of BUCKET_TYPES) {
-      if (
-        !(await checkBucketExists(
-          bucketDefs[bucketType],
-          `config.buckets[${x.toString()}].${bucketType}`,
-          storage,
-        ))
-      ) {
-        success = false;
-      }
-    }
+    const bucketName = config.buckets[x] as string;
     if (
-      bucketDefs.unscanned === bucketDefs.clean ||
-      bucketDefs.unscanned === bucketDefs.quarantined ||
-      bucketDefs.clean === bucketDefs.quarantined
+      !(await checkBucketExists(
+        bucketName,
+        `config.buckets[${x.toString()}]`,
+        storage,
+      ))
     ) {
-      logger.fatal(
-        `Config Error: buckets[${x.toString()}]: bucket names are not unique`,
-      );
       success = false;
     }
   }

--- a/cloudrun-malware-scanner/scanner.ts
+++ b/cloudrun-malware-scanner/scanner.ts
@@ -15,7 +15,7 @@
  */
 
 import {logger} from './logger';
-import {Config, BucketDefs} from './config.js';
+import {Config} from './config.js';
 import * as gcs from '@google-cloud/storage';
 import * as ClamdClient from 'clamdjs';
 import * as metrics from './metrics';
@@ -109,16 +109,11 @@ export class Scanner {
     storageObject: StorageObjectData,
   ): Promise<ScanResponse> {
     try {
-      let bucketDefs: BucketDefs | undefined;
-
       try {
         this.validateStorageObject(storageObject);
-        bucketDefs = this.config.buckets.filter(
-          (bucketDefs) => bucketDefs.unscanned === storageObject.bucket,
-        )[0];
-        if (bucketDefs == null) {
+        if (!this.config.buckets.includes(storageObject.bucket)) {
           throw new Error(
-            `Request has bucket name ${storageObject.bucket} which is not an unscanned bucket in config`,
+            `Request has bucket name ${storageObject.bucket} which is not configured for scanning`,
           );
         }
       } catch (e) {
@@ -143,8 +138,8 @@ export class Scanner {
           `Scan status for gs://${storageObject.bucket}/${storageObject.name}: IGNORED (zero length file})`,
         );
         this.metricsClient.writeScanIgnored(
-          bucketDefs.unscanned,
-          bucketDefs.clean,
+          storageObject.bucket,
+          storageObject.bucket,
           fileSize,
           'ZERO_LENGTH_FILE',
         );
@@ -166,8 +161,8 @@ export class Scanner {
           `Scan status for gs://${storageObject.bucket}/${storageObject.name}: IGNORED (file too large at ${fileSize} bytes})`,
         );
         this.metricsClient.writeScanIgnored(
-          bucketDefs.unscanned,
-          bucketDefs.clean,
+          storageObject.bucket,
+          storageObject.bucket,
           fileSize,
           'FILE_TOO_LARGE',
         );
@@ -190,8 +185,8 @@ export class Scanner {
             `Scan status for gs://${storageObject.bucket}/${storageObject.name}: IGNORED (matched regex: ${regexp.toString()})`,
           );
           this.metricsClient.writeScanIgnored(
-            bucketDefs.unscanned,
-            bucketDefs.clean,
+            storageObject.bucket,
+            storageObject.bucket,
             fileSize,
             'REGEXP_MATCH',
             regexp.toString(),
@@ -231,8 +226,8 @@ export class Scanner {
           `Scan status for ${gcsFile.cloudStorageURI.href}: IGNORED (File size mismatch (reported: ${fileSize}, metadata: ${metadataSize}). File upload may not be complete).`,
         );
         this.metricsClient.writeScanIgnored(
-          bucketDefs.unscanned,
-          bucketDefs.clean,
+          storageObject.bucket,
+          storageObject.bucket,
           fileSize,
           'FILE_SIZE_MISMATCH',
         );
@@ -298,14 +293,14 @@ export class Scanner {
           `Scan status for ${gcsFile.cloudStorageURI.href}: CLEAN (${fileSize} bytes in ${scanDuration} ms)`,
         );
         this.metricsClient.writeScanClean(
-          bucketDefs.unscanned,
-          bucketDefs.clean,
+          storageObject.bucket,
+          storageObject.bucket,
           fileSize,
           scanDuration,
           clamdVersion,
         );
 
-        await this.moveProcessedFile(gcsFile, bucketDefs.clean);
+        // File is left in place, only log result
 
         return {
           status: 'clean',
@@ -328,14 +323,23 @@ export class Scanner {
           `Scan status for ${gcsFile.cloudStorageURI.href}: INFECTED ${result} (${fileSize} bytes in ${scanDuration} ms)`,
         );
         this.metricsClient.writeScanInfected(
-          bucketDefs.unscanned,
-          bucketDefs.quarantined,
+          storageObject.bucket,
+          storageObject.bucket,
           fileSize,
           scanDuration,
           clamdVersion,
         );
 
-        await this.moveProcessedFile(gcsFile, bucketDefs.quarantined);
+        const [bucketMeta] = await this.storageClient
+          .bucket(storageObject.bucket)
+          .getMetadata();
+        const ownerEmail =
+          bucketMeta.labels?.ownerEmail ||
+          bucketMeta.owner?.entity ||
+          'unknown';
+        logger.warn(
+          `Malware detected in bucket ${storageObject.bucket} owned by ${ownerEmail}`,
+        );
 
         return {
           message: result,

--- a/cloudrun-malware-scanner/spec/config.spec.ts
+++ b/cloudrun-malware-scanner/spec/config.spec.ts
@@ -18,13 +18,7 @@ import * as Config from '../config.js';
 import * as gcs from '@google-cloud/storage';
 
 const GOOD_CONFIG: Config.Config = {
-  buckets: [
-    {
-      unscanned: 'unscannedBucket',
-      quarantined: 'quarantinedBucket',
-      clean: 'cleanBucket',
-    },
-  ],
+  buckets: ['scanBucket'],
   ClamCvdMirrorBucket: 'csvMirrorBucket',
   fileExclusionRegexps: [],
   ignoreZeroLengthFiles: false,
@@ -48,10 +42,7 @@ describe('Config', () => {
       'getFiles',
     ]);
     (existingBucket.getFiles as jasmine.Spy).and.resolveTo([]);
-    [
-      ...Object.values(GOOD_CONFIG.buckets[0]),
-      GOOD_CONFIG.ClamCvdMirrorBucket,
-    ].forEach((bucket) =>
+    [...GOOD_CONFIG.buckets, GOOD_CONFIG.ClamCvdMirrorBucket].forEach((bucket) =>
       (storageServiceSpy.bucket as jasmine.Spy)
         .withArgs(bucket)
         .and.returnValue(existingBucket),
@@ -84,7 +75,7 @@ describe('Config', () => {
       );
       expect(config).toEqual(GOOD_CONFIG);
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(existingBucket.getFiles as jasmine.Spy).toHaveBeenCalledTimes(4);
+      expect(existingBucket.getFiles as jasmine.Spy).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -150,61 +141,6 @@ describe('Config', () => {
       ).toBeResolvedTo(GOOD_CONFIG);
     });
 
-    it('missing buckets trigger failure', async () => {
-      const nonExistingBucket = jasmine.createSpyObj('bucket', ['getFiles']);
-      (storageServiceSpy.bucket as jasmine.Spy)
-        .withArgs('nonExistingBucket')
-        .and.returnValue(nonExistingBucket);
-      (nonExistingBucket.getFiles as jasmine.Spy).and.rejectWith(
-        new Error('Bucket not found'),
-      );
-
-      const config = structuredClone(GOOD_CONFIG);
-
-      config.ClamCvdMirrorBucket = 'nonExistingBucket';
-      await expectAsync(
-        Config.TEST_ONLY.validateConfig(config, storageServiceSpy),
-      ).toBeRejectedWithError('Invalid configuration');
-
-      config.ClamCvdMirrorBucket = GOOD_CONFIG.ClamCvdMirrorBucket;
-      config.buckets[0].clean = 'nonExistingBucket';
-      await expectAsync(
-        Config.TEST_ONLY.validateConfig(config, storageServiceSpy),
-      ).toBeRejectedWithError('Invalid configuration');
-
-      config.buckets[0].clean = GOOD_CONFIG.buckets[0].clean;
-      config.buckets[0].unscanned = 'nonExistingBucket';
-      await expectAsync(
-        Config.TEST_ONLY.validateConfig(config, storageServiceSpy),
-      ).toBeRejectedWithError('Invalid configuration');
-
-      config.buckets[0].unscanned = GOOD_CONFIG.buckets[0].unscanned;
-      config.buckets[0].quarantined = 'nonExistingBucket';
-      await expectAsync(
-        Config.TEST_ONLY.validateConfig(config, storageServiceSpy),
-      ).toBeRejectedWithError('Invalid configuration');
-    });
-
-    it('identical buckets in same group trigger failure', async () => {
-      const config = structuredClone(GOOD_CONFIG);
-
-      config.buckets[0].quarantined = GOOD_CONFIG.buckets[0].unscanned;
-      await expectAsync(
-        Config.TEST_ONLY.validateConfig(config, storageServiceSpy),
-      ).toBeRejectedWithError('Invalid configuration');
-
-      config.buckets[0].quarantined = GOOD_CONFIG.buckets[0].quarantined;
-      config.buckets[0].clean = GOOD_CONFIG.buckets[0].unscanned;
-      await expectAsync(
-        Config.TEST_ONLY.validateConfig(config, storageServiceSpy),
-      ).toBeRejectedWithError('Invalid configuration');
-
-      config.buckets[0].clean = GOOD_CONFIG.buckets[0].clean;
-      config.buckets[0].quarantined = GOOD_CONFIG.buckets[0].clean;
-      await expectAsync(
-        Config.TEST_ONLY.validateConfig(config, storageServiceSpy),
-      ).toBeRejectedWithError('Invalid configuration');
-    });
 
     it('validates ignoreZeroLengthFiles', async () => {
       let config = structuredClone(GOOD_CONFIG) as any;

--- a/cloudrun-malware-scanner/spec/scanner.spec.ts
+++ b/cloudrun-malware-scanner/spec/scanner.spec.ts
@@ -22,13 +22,7 @@ import * as gcs from '@google-cloud/storage';
 import * as ClamdClient from 'clamdjs';
 
 const CONFIG: Config = {
-  buckets: [
-    {
-      unscanned: 'unscannedBucket',
-      quarantined: 'quarantinedBucket',
-      clean: 'cleanBucket',
-    },
-  ],
+  buckets: ['scanBucket'],
   ClamCvdMirrorBucket: 'csvMirrorBucket',
   fileExclusionRegexps: [],
   ignoreZeroLengthFiles: false,
@@ -49,8 +43,6 @@ describe('Scanner', () => {
   let metricsClient: jasmine.SpyObj<typeof metrics>;
   let storageClient: jasmine.SpyObj<gcs.Storage>;
   let mockUnscannedBucket: jasmine.SpyObj<gcs.Bucket>;
-  let mockCleanBucket: jasmine.SpyObj<gcs.Bucket>;
-  let mockQuarantinedBucket: jasmine.SpyObj<gcs.Bucket>;
   let mockFile: jasmine.SpyObj<gcs.File>;
 
   let scanner: Scanner;
@@ -80,35 +72,19 @@ describe('Scanner', () => {
     storageClient = jasmine.createSpyObj<gcs.Storage>('Storage', ['bucket']);
 
     mockUnscannedBucket = jasmine.createSpyObj<gcs.Bucket>(
-      'unscannedBucket',
-      ['file'],
+      'scanBucket',
+      ['file', 'getMetadata'],
       {
-        name: 'unscannedBucket',
+        name: 'scanBucket',
       },
     );
     storageClient.bucket
-      .withArgs('unscannedBucket')
-      .and.returnValue(mockUnscannedBucket);
+  .withArgs('scanBucket')
+  .and.returnValue(mockUnscannedBucket);
+    (mockUnscannedBucket.getMetadata as jasmine.Spy).and.resolveTo([
+      {labels: {ownerEmail: 'owner@example.com'}},
+    ]);
 
-    mockCleanBucket = jasmine.createSpyObj<gcs.Bucket>(
-      'cleanBucket',
-      ['file'],
-      {
-        name: 'cleanBucket',
-      },
-    );
-    storageClient.bucket
-      .withArgs('cleanBucket')
-      .and.returnValue(mockCleanBucket);
-
-    mockQuarantinedBucket = jasmine.createSpyObj<gcs.Bucket>(
-      'quarantinedBucket',
-      ['file'],
-      {name: 'quarantinedBucket'},
-    );
-    storageClient.bucket
-      .withArgs('quarantinedBucket')
-      .and.returnValue(mockQuarantinedBucket);
 
     mockFile = jasmine.createSpyObj<gcs.File>(
       'testFile',
@@ -116,7 +92,7 @@ describe('Scanner', () => {
       {
         name: TEST_FILE_NAME,
         cloudStorageURI: new URL(
-          `gs://${CONFIG.buckets[0].clean}/${TEST_FILE_NAME}`,
+          `gs://${CONFIG.buckets[0]}/${TEST_FILE_NAME}`,
         ),
       },
     );
@@ -207,14 +183,14 @@ describe('Scanner', () => {
 
       scanner = new Scanner(config, clamdClient, storageClient, metricsClient);
 
-      const request = {name: 'filename', bucket: 'unscannedBucket', size: 0};
+      const request = {name: 'filename', bucket: 'scanBucket', size: 0};
       await expectAsync(scanner.handleGcsObject(request)).toBeResolvedTo({
         status: 'ignored',
         message: 'zero_length_file',
       });
       expect(metricsClient.writeScanIgnored).toHaveBeenCalledWith(
-        CONFIG.buckets[0].unscanned,
-        CONFIG.buckets[0].clean,
+        CONFIG.buckets[0],
+        CONFIG.buckets[0],
         0,
         'ZERO_LENGTH_FILE',
       );
@@ -223,7 +199,7 @@ describe('Scanner', () => {
     it('ignores files that are too large', async () => {
       const request = {
         name: 'filename',
-        bucket: 'unscannedBucket',
+        bucket: 'scanBucket',
         size: 501000000,
       };
       await expectAsync(scanner.handleGcsObject(request)).toBeResolvedTo({
@@ -231,8 +207,8 @@ describe('Scanner', () => {
         message: 'file_too_large',
       });
       expect(metricsClient.writeScanIgnored).toHaveBeenCalledWith(
-        CONFIG.buckets[0].unscanned,
-        CONFIG.buckets[0].clean,
+        CONFIG.buckets[0],
+        CONFIG.buckets[0],
         request.size,
         'FILE_TOO_LARGE',
       );
@@ -244,7 +220,7 @@ describe('Scanner', () => {
 
       scanner = new Scanner(config, clamdClient, storageClient, metricsClient);
 
-      const request = {name: 'file.tmp', bucket: 'unscannedBucket', size: 100};
+      const request = {name: 'file.tmp', bucket: 'scanBucket', size: 100};
       await expectAsync(scanner.handleGcsObject(request)).toBeResolvedTo({
         status: 'ignored',
         message: 'exclusion_regexp_match',
@@ -257,15 +233,15 @@ describe('Scanner', () => {
       });
 
       expect(metricsClient.writeScanIgnored).toHaveBeenCalledWith(
-        CONFIG.buckets[0].unscanned,
-        CONFIG.buckets[0].clean,
+        CONFIG.buckets[0],
+        CONFIG.buckets[0],
         100,
         'REGEXP_MATCH',
         '/\\.tmp$/',
       );
       expect(metricsClient.writeScanIgnored).toHaveBeenCalledWith(
-        CONFIG.buckets[0].unscanned,
-        CONFIG.buckets[0].clean,
+        CONFIG.buckets[0],
+        CONFIG.buckets[0],
         100,
         'REGEXP_MATCH',
         '/\\.multipart\\./i',
@@ -277,7 +253,7 @@ describe('Scanner', () => {
 
       const request = {
         name: TEST_FILE_NAME,
-        bucket: 'unscannedBucket',
+        bucket: 'scanBucket',
         size: 100,
       };
       await expectAsync(scanner.handleGcsObject(request)).toBeResolvedTo({
@@ -295,7 +271,7 @@ describe('Scanner', () => {
 
       const request = {
         name: TEST_FILE_NAME,
-        bucket: 'unscannedBucket',
+        bucket: 'scanBucket',
         size: 100,
       };
       await expectAsync(scanner.handleGcsObject(request)).toBeResolvedTo({
@@ -303,8 +279,8 @@ describe('Scanner', () => {
         message: 'file_size_mismatch',
       });
       expect(metricsClient.writeScanIgnored).toHaveBeenCalledWith(
-        CONFIG.buckets[0].unscanned,
-        CONFIG.buckets[0].clean,
+        CONFIG.buckets[0],
+        CONFIG.buckets[0],
         100,
         'FILE_SIZE_MISMATCH',
       );
@@ -315,7 +291,7 @@ describe('Scanner', () => {
     describe('scans files', () => {
       const request = {
         name: TEST_FILE_NAME,
-        bucket: 'unscannedBucket',
+        bucket: 'scanBucket',
         size: 100,
       };
       let mockReadStream: jasmine.SpyObj<Readable>;
@@ -344,7 +320,7 @@ describe('Scanner', () => {
         ).toBeRejectedWithError('createReadStream Fail');
 
         expect(metricsClient.writeScanFailed).toHaveBeenCalledWith(
-          CONFIG.buckets[0].unscanned,
+          CONFIG.buckets[0],
         );
       });
 
@@ -354,7 +330,7 @@ describe('Scanner', () => {
           'scanfile fail',
         );
         expect(metricsClient.writeScanFailed).toHaveBeenCalledWith(
-          CONFIG.buckets[0].unscanned,
+          CONFIG.buckets[0],
         );
         // eslint-disable-next-line @typescript-eslint/unbound-method
         expect(mockReadStream.destroy).toHaveBeenCalled();
@@ -374,11 +350,10 @@ describe('Scanner', () => {
         // eslint-disable-next-line @typescript-eslint/unbound-method
         expect(mockReadStream.destroy).toHaveBeenCalled();
         // .toHaveBeenCalledWith does not work due to overloading of func.
-        expect(mockFile.move.calls.count()).toBe(1);
-        expect(mockFile.move.calls.first().args[0]).toBe(mockCleanBucket);
+        expect(mockFile.move).not.toHaveBeenCalled();
         expect(metricsClient.writeScanClean).toHaveBeenCalledWith(
-          CONFIG.buckets[0].unscanned,
-          CONFIG.buckets[0].clean,
+          CONFIG.buckets[0],
+          CONFIG.buckets[0],
           100,
           0,
           CLAMD_VERSION_STRING,
@@ -399,11 +374,10 @@ describe('Scanner', () => {
         // eslint-disable-next-line @typescript-eslint/unbound-method
         expect(mockReadStream.destroy).toHaveBeenCalled();
         // .toHaveBeenCalledWith does not work due to overloading of func.
-        expect(mockFile.move.calls.count()).toBe(1);
-        expect(mockFile.move.calls.first().args[0]).toBe(mockQuarantinedBucket);
+        expect(mockFile.move).not.toHaveBeenCalled();
         expect(metricsClient.writeScanInfected).toHaveBeenCalledWith(
-          CONFIG.buckets[0].unscanned,
-          CONFIG.buckets[0].quarantined,
+          CONFIG.buckets[0],
+          CONFIG.buckets[0],
           100,
           0,
           CLAMD_VERSION_STRING,
@@ -433,11 +407,10 @@ describe('Scanner', () => {
         // eslint-disable-next-line @typescript-eslint/unbound-method
         expect(mockReadStream.destroy).toHaveBeenCalled();
         // .toHaveBeenCalledWith does not work due to overloading of func.
-        expect(mockFile.move.calls.count()).toBe(1);
-        expect(mockFile.move.calls.first().args[0]).toBe(mockQuarantinedBucket);
+        expect(mockFile.move).not.toHaveBeenCalled();
         expect(metricsClient.writeScanInfected).toHaveBeenCalledWith(
-          CONFIG.buckets[0].unscanned,
-          CONFIG.buckets[0].quarantined,
+          CONFIG.buckets[0],
+          CONFIG.buckets[0],
           100,
           0,
           CLAMD_VERSION_STRING,
@@ -466,11 +439,10 @@ describe('Scanner', () => {
         // eslint-disable-next-line @typescript-eslint/unbound-method
         expect(mockReadStream.destroy).toHaveBeenCalled();
         // .toHaveBeenCalledWith does not work due to overloading of func.
-        expect(mockFile.move.calls.count()).toBe(1);
-        expect(mockFile.move.calls.first().args[0]).toBe(mockQuarantinedBucket);
+        expect(mockFile.move).not.toHaveBeenCalled();
         expect(metricsClient.writeScanInfected).toHaveBeenCalledWith(
-          CONFIG.buckets[0].unscanned,
-          CONFIG.buckets[0].quarantined,
+          CONFIG.buckets[0],
+          CONFIG.buckets[0],
           100,
           0,
           CLAMD_VERSION_STRING,

--- a/cloudrun-malware-scanner/spec/support/good-config.json
+++ b/cloudrun-malware-scanner/spec/support/good-config.json
@@ -1,12 +1,6 @@
 {
   "comments": ["Some comments"],
-  "buckets": [
-    {
-      "unscanned": "unscannedBucket",
-      "quarantined": "quarantinedBucket",
-      "clean": "cleanBucket"
-    }
-  ],
+  "buckets": ["scanBucket"],
   "ClamCvdMirrorBucket": "csvMirrorBucket",
   "quarantine": {
     "fileExtensionAllowList": [],


### PR DESCRIPTION
## Summary
- update README for new log-only behavior
- update configuration template for single bucket list
- refactor config validation for list of buckets
- modify scanner to keep files in place and log bucket owner on infection
- update unit tests for new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ab8329bc48323aa9dc08c75cbd974