### PR TITLE
Fix outdated bucket references in README

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -46,11 +46,7 @@ TF_VAR_project_id=$PROJECT_ID
 TF_VAR_config_json=$(cat <<EOF
 {
   "buckets": [
-    {
-      "unscanned": "unscanned-${PROJECT_ID}",
-      "clean": "clean-${PROJECT_ID}",
-      "quarantined": "quarantined-${PROJECT_ID}"
-    }
+    "bucket-${PROJECT_ID}"
   ],
   "ClamCvdMirrorBucket": "cvd-mirror-${PROJECT_ID}",
   "fileExclusionPatterns": [["\\\\.tmp$","i"]],
@@ -131,8 +127,8 @@ Responding yes when prompted.
 This terraform module performs the following:
 
 - Deploys the malware-scanner service to Cloud Run using the image you built.
-- Set up EventArc triggers on the configured unscanned buckets to launch a
-  malware scan when files are uploaded to those buckets.
+- Set up EventArc triggers on the configured buckets to launch a
+  malware scan when files are uploaded.
 - Set up a Cloud Scheduler job to periodically trigger an update of the ClamAV
   malware definitions mirror.
 
@@ -147,9 +143,8 @@ the `terraform apply -auto-approve` command
 
 ## Test the service
 
-The service can be tested by querying the version numbers from the cloud run
-service, and by verifying the operation by uploading files to the unscanned GCS
-bucket.
+The service can be tested by querying the version numbers from the Cloud Run
+service and by uploading files to one of the configured GCS buckets.
 
 ### Get version info from cloud run
 
@@ -168,48 +163,29 @@ ClamAV and the current malware definitions version/datem for example:
 gcs-malware-scanner version 3.0.0
 Using Clam AV version: ClamAV 1.0.5/27396/Thu Sep 12 08:46:40 2024
 
-Service to scan GCS documents for the malware and move the analyzed documents to appropriate buckets
+Service to scan GCS documents for malware
 ```
 
 ### Create and scan a clean file and an simulated infected file
 
-Run the following command to create 2 files in the unscanned bucket, a simple
+Run the following command to create 2 files in the bucket, a simple
 `clean.txt` file and an `eicar-infected.txt` file containing a
 [test string which simulates a virus](https://en.wikipedia.org/wiki/EICAR_test_file)
 
 ```bash
 echo -e 'HELLO WORLD!' \
-    | gcloud storage cp - "gs://unscanned-${PROJECT_ID}/clean.txt"
+    | gcloud storage cp - "gs://bucket-${PROJECT_ID}/clean.txt"
 echo -e 'X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*' \
-    | gcloud storage cp - "gs://unscanned-${PROJECT_ID}/eicar-infected.txt"
+    | gcloud storage cp - "gs://bucket-${PROJECT_ID}/eicar-infected.txt"
 ```
 
-Check contents of the unscanned bucket
+Check contents of the bucket
 
 ```bash
-gcloud storage ls gs://unscanned-${PROJECT_ID}/
+gcloud storage ls gs://bucket-${PROJECT_ID}/
 ```
 
-This should return no results as the files will have been moved by the
-malware-scanner. If the files still exist, re-run the command after a couple of
-seconds.
-
-Check contents of the clean files bucket
-
-```bash
-gcloud storage ls gs://clean-${PROJECT_ID}/
-```
-
-This should show that the clean.txt file has been moved to the clean bucket.
-
-Check contents of the quarantined bucket:
-
-```bash
-gcloud storage ls gs://quarantined-${PROJECT_ID}/
-```
-
-This should show that the eicar-infected.txt file has been moved to the
-quarantined bucket.
+The files remain in place. Review the service logs to verify the scan status.
 
 Show the log items with the scan status:
 
@@ -222,6 +198,6 @@ gcloud logging read \
 This will output log lines similar to:
 
 ```text
-Scan status for gs://unscanned-PROJECT_ID/clean.txt: CLEAN (13 bytes in 85 ms)
-Scan status for gs://unscanned-PROJECT_ID/eicar-infected.txt: INFECTED stream: Eicar-Signature FOUND (69 bytes in 77 ms)
+Scan status for gs://bucket-PROJECT_ID/clean.txt: CLEAN (13 bytes in 85 ms)
+Scan status for gs://bucket-PROJECT_ID/eicar-infected.txt: INFECTED stream: Eicar-Signature FOUND (69 bytes in 77 ms)
 ```


### PR DESCRIPTION
## Summary
- update Terraform deployment instructions
- use single bucket examples instead of separate unscanned, clean and quarantined buckets

## Testing
- `npm test` *(fails: Cannot find name 'expect')*

------
https://chatgpt.com/codex/tasks/task_e_685bb6e1cc288323933698c90d107ac2